### PR TITLE
fix dupe menu item build error

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -20,7 +20,7 @@ canonifyurls = "false"
     weight = 30
     url = "/eicutables/"
 [[menu.main]]
-    name = "Schema"
+    name = "SchemaSpy"
     pre = "<i class='fa fa-table'></i>"
     weight = 40
     url = "https://mit-lcp.github.io/eicu-schema-spy/"


### PR DESCRIPTION
Rename "Schema" to "SchemaSpy" in menu. Fixes build error due to duplicate menu items.

```
remote: Building sites … ERROR 2018/07/19 09:06:03 Two or more menu items have the same name/identifier in Menu "main": "Schema".
remote: Rename or set an unique identifier.
```