### PR TITLE
Replaces REGEXP_CONTAINS with ~ in pivoted-gcs.sql

### DIFF
--- a/concepts/pivoted/pivoted-gcs.sql
+++ b/concepts/pivoted/pivoted-gcs.sql
@@ -6,12 +6,12 @@ select
   , min(case
       when nursingchartcelltypevallabel = 'Glasgow coma score'
        and nursingchartcelltypevalname = 'GCS Total'
-       and REGEXP_CONTAINS(nursingchartvalue, '^[-]?[0-9]+[.]?[0-9]*$')
+       and nursingchartvalue ~ '^[-]?[0-9]+[.]?[0-9]*$'
        and nursingchartvalue not in ('-','.')
           then cast(nursingchartvalue as numeric)
       when nursingchartcelltypevallabel = 'Score (Glasgow Coma Scale)'
        and nursingchartcelltypevalname = 'Value'
-       and REGEXP_CONTAINS(nursingchartvalue, '^[-]?[0-9]+[.]?[0-9]*$')
+       and nursingchartvalue ~ '^[-]?[0-9]+[.]?[0-9]*$'
        and nursingchartvalue not in ('-','.')
           then cast(nursingchartvalue as numeric)
       else null end)
@@ -19,7 +19,7 @@ select
   , min(case
       when nursingchartcelltypevallabel = 'Glasgow coma score'
        and nursingchartcelltypevalname = 'Motor'
-       and REGEXP_CONTAINS(nursingchartvalue, '^[-]?[0-9]+[.]?[0-9]*$')
+       and nursingchartvalue ~ '^[-]?[0-9]+[.]?[0-9]*$'
        and nursingchartvalue not in ('-','.')
           then cast(nursingchartvalue as numeric)
       else null end)
@@ -27,7 +27,7 @@ select
   , min(case
       when nursingchartcelltypevallabel = 'Glasgow coma score'
        and nursingchartcelltypevalname = 'Verbal'
-       and REGEXP_CONTAINS(nursingchartvalue, '^[-]?[0-9]+[.]?[0-9]*$')
+       and nursingchartvalue ~ '^[-]?[0-9]+[.]?[0-9]*$'
        and nursingchartvalue not in ('-','.')
           then cast(nursingchartvalue as numeric)
       else null end)
@@ -35,7 +35,7 @@ select
   , min(case
       when nursingchartcelltypevallabel = 'Glasgow coma score'
        and nursingchartcelltypevalname = 'Eyes'
-       and REGEXP_CONTAINS(nursingchartvalue, '^[-]?[0-9]+[.]?[0-9]*$')
+       and nursingchartvalue ~ '^[-]?[0-9]+[.]?[0-9]*$'
        and nursingchartvalue not in ('-','.')
           then cast(nursingchartvalue as numeric)
       else null end)


### PR DESCRIPTION
Rewrite `REGEXP_CONTAINS(nursingchartvalue, '^[-]?[0-9]+[.]?[0-9]*$')` as `nursingchartvalue ~ '^[-]?[0-9]+[.]?[0-9]*$'` for compatibility with Postgres.

Fixes Issue #117.