### PR TITLE
Fix Documentation vitalPeriodicID row of vitalPeriodic table

### DIFF
--- a/website/content/eicutables/admissiondrug.md
+++ b/website/content/eicutables/admissiondrug.md
@@ -36,7 +36,7 @@ Name | Datatype | Null Option | Comment | Is Key | Stored Transformed Created
 `rxIncluded` | varchar(5) | NOT NULL | Does the Note have associated Rx data: True or False |  | S
 `writtenIneICU` | varchar(5) | NOT NULL | Was the Note written in the eICU: True or False |  | S
 `drugName` | varchar(255) | NOT NULL | name of the selected admission drug e.g.: POTASSIUM CHLORIDE/D5NS METAXALONE PRAVACHOL |  | S
-drugDosage | decimal(11,4) | NULL | dosage of the admission drug e.g.: 20.0000 400.000 |  | S
+`drugDosage` | decimal(11,4) | NULL | dosage of the admission drug e.g.: 20.0000 400.000 |  | S
 `drugUnit` | varchar(1000) | NULL | picklist units of the admission drug e.g.: mg mg/kg patch |  | S
 `drugAdmitFrequency` | varchar(1000) | NULL | picklist frequency with which the admission drug is administred e.g.: PRN twice a day at bedtime |  | S
 `drugHiclSeqno` | int | NULL | HICL sequence number for the drug e.g.: 2734 33199 20492 |  | S

--- a/website/content/eicutables/vitalPeriodic.md
+++ b/website/content/eicutables/vitalPeriodic.md
@@ -44,7 +44,7 @@ vitalPeriodic data represents the 5 minute median values from the bedside vital 
 Name | Datatype | Null Option | Comment | Is Key | Stored Transformed Created
 ---- | ---- | ---- | ---- | ---- | ----
 `patientUnitStayID` | int | NOT NULL | foreign key link to the patient table | FK | C
-`vitalPeriodicID` | int | IDENTITY | surrogate key for periodic value | PK C
+`vitalPeriodicID` | int | IDENTITY | surrogate key for periodic value | PK | C
 `observationOffset` | int | NOT NULL | number of minutes from unit admit time that the periodic value was entered |  | C
 `temperature` | decimal(11,4) | NULL | patient's temperature value in celsius e.g.: 36.1000, 37.8000, 35.5000, etc. |  | S
 `saO2` | int | NULL | patient's saO2 value e.g.: 99, 94, 98, etc. |  | S


### PR DESCRIPTION
Fix a typo in `website/content/eicutables/vitalPeriodic.md` where a pipe was missing to separate two columns.  Additionally format `drugDosage` as `fixed width text` in the `admissiondrug` table in the `website/content/eicutables/admissiondrug.md` file